### PR TITLE
Fix exported API for fetch-engine-node

### DIFF
--- a/src/fetch-engine-browser.test.ts
+++ b/src/fetch-engine-browser.test.ts
@@ -2,12 +2,26 @@
 "use strict";
 import test = require("tape");
 import wrap from "./utils/wrapPromiseTest";
-import Request from "./Request";
-import fetchEngine from "./fetch-engine-browser";
+import fetchEngine, { Request, FetchGroup, Response } from "./fetch-engine-browser";
 
 test("browser fetchEngine is requireable", t => {
   t.plan(1);
   t.ok(fetchEngine);
+});
+
+test("browser FetchGroup is requireable", t => {
+  t.plan(1);
+  t.ok(FetchGroup);
+});
+
+test("browser Request is requireable", t => {
+  t.plan(1);
+  t.ok(Request);
+});
+
+test("browser Response is requireable", t => {
+  t.plan(1);
+  t.ok(Response);
 });
 
 test("browser fetchEngine can make a request to the test server", wrap(t => {

--- a/src/fetch-engine-node.test.ts
+++ b/src/fetch-engine-node.test.ts
@@ -1,0 +1,41 @@
+/// <reference path="./.d.test.ts" />
+"use strict";
+import test = require("tape");
+import wrap from "./utils/wrapPromiseTest";
+import fetchEngine, { Request, FetchGroup, Response } from "./fetch-engine-node";
+
+test("node fetchEngine is requireable", t => {
+  t.plan(1);
+  t.ok(fetchEngine);
+});
+
+test("node FetchGroup is requireable", t => {
+  t.plan(1);
+  t.ok(FetchGroup);
+});
+
+test("node Request is requireable", t => {
+  t.plan(1);
+  t.ok(Request);
+});
+
+test("node Response is requireable", t => {
+  t.plan(1);
+  t.ok(Response);
+});
+
+test("browser fetchEngine can make a request to the test server", wrap(t => {
+  t.plan(2);
+  const req = new Request(
+    `/echo/text/${encodeURIComponent("Hello fetch-node")}`
+  );
+  const fetch = fetchEngine();
+  return fetch(req)
+    .then(res => {
+      t.ok(res);
+      return res.text();
+    })
+    .then(text => {
+      t.equal(text, "Hello fetch-node");
+    });
+}));

--- a/src/fetch-engine-node.ts
+++ b/src/fetch-engine-node.ts
@@ -3,4 +3,11 @@
 
 import makeFetchEngine from "./fetchEngine";
 import fetch from "./fetch/fetch-node";
-module.exports = makeFetchEngine(fetch);
+import FetchGroup from "./FetchGroup";
+import Request from "./Request";
+import Response from "./Response";
+
+const fetchEngine = makeFetchEngine(fetch);
+export default fetchEngine;
+export { FetchGroup, Request, Response };
+


### PR DESCRIPTION
`fetch-engine-node`'s exports currently do not include: `Request`, `Response` and `FetchGroup`, which is incorrect.

This pull-request:

- Adds tests for `fetch-engine-browser` to ensure that we export the correct API
- Fixes the `fetch-engine-node`'s exports
- Adds tests for `fetch-engine-node` to ensure that we export the correct API