### PR TITLE
feat: makeFetchGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,52 @@ const fetch = fetchEngine({
 });
 ```
 
-<!-- TODO make fetchGroup({ ... }) factory -->
+#### Reusable groups
+
+Some kinds of Group need to be stateful, for functionality like rate limiting and tracking retries.
+
+`fetch-engine` exports a utility to help you to this: `makeFetchGroup`.
+
+`makeFetchGroup` takes a function that, when called, should return an object of `FetchGroup` options, and it returns a constructor function.
+
+The first argument passed to the group constructor is forwared to the options function, allowing you to customise the configuration of the group on an instance-by-instance basis.
+
+Here's two examples:
+
+```js
+const RateLimitGroup = makeFetchGroup(() => ({
+  filters: [
+    new MethodFilter("GET")
+  ],
+  plugins: [
+    new RateLimitPlugin()
+  ]
+}));
+
+const fetch = fetchEngine({
+  plugins: [
+    new RateLimitGroup()
+  ]
+});
+
+const PathRateLimitGroup = makeFetchGroup((opts = {}) => ({
+  filters: [
+    new MethodFilter("GET"),
+    new PathFilter(opts.path || /.*/))
+  ],
+  plugins: [
+    new RateLimitPlugin()
+  ]
+}));
+
+const fetch = fetchEngine({
+  plugins: [
+    new PathRateLimitGroup({
+      path: /^\/1\.1/
+    })
+  ]
+});
+```
 
 ### Filters
 

--- a/src/FetchGroup.test.ts
+++ b/src/FetchGroup.test.ts
@@ -1,4 +1,4 @@
-// tslint:disable:no-var-requires
+// tslint:disable:no-var-requires max-classes-per-file
 require("isomorphic-fetch");
 import * as test from "tape";
 import {

--- a/src/FetchGroup.ts
+++ b/src/FetchGroup.ts
@@ -1,6 +1,7 @@
 import {
   FetchNext,
   FetchRetry,
+  IFetchEngineFilter,
   IFetchEnginePlugin,
   IFetchFetchingArgs,
   IFetchGroupOptions,
@@ -12,6 +13,8 @@ import composeVoid from "./utils/composeVoid";
 import getBoundImplementations from "./utils/getBoundImplementations";
 
 export default class FetchGroup implements IFetchEnginePlugin {
+  public plugins: IFetchEnginePlugin[];
+  public filters: IFetchEngineFilter[];
   /* tslint:disable:variable-name */
   // Filters
   private _testRequest: (req: Request) => boolean;
@@ -30,6 +33,10 @@ export default class FetchGroup implements IFetchEnginePlugin {
   /* tslint:enable:variable-name */
   constructor(opts: IFetchGroupOptions = {}) {
     const { plugins = [], filters = [] }: IFetchGroupOptions = opts;
+
+    // Store the original filters & plugins
+    this.plugins = plugins;
+    this.filters = filters;
 
     // Filters
     this._testRequest =

--- a/src/fetch-engine-browser.test.ts
+++ b/src/fetch-engine-browser.test.ts
@@ -1,12 +1,22 @@
 // tslint:disable:no-var-requires
 require("isomorphic-fetch");
 import * as test from "tape";
-import fetchEngine from "./fetch-engine-browser";
+import fetchEngine, { FetchGroup, makeFetchGroup } from "./fetch-engine-browser";
 import wrap from "./utils/wrapPromiseTest";
 
 test("browser fetchEngine is requireable", (t) => {
   t.plan(1);
   t.ok(fetchEngine);
+});
+
+test("browser fetchEngine exports FetchGroup", (t) => {
+  t.plan(1);
+  t.ok(FetchGroup);
+});
+
+test("browser fetchEngine exports makeFetchGroup", (t) => {
+  t.plan(1);
+  t.ok(makeFetchGroup);
 });
 
 test("browser fetchEngine can make a request to the test server", wrap((t) => {
@@ -16,6 +26,80 @@ test("browser fetchEngine can make a request to the test server", wrap((t) => {
   );
   const fetch = fetchEngine();
   return fetch(req)
+    .then((res) => {
+      t.ok(res);
+      return res.text();
+    })
+    .then((text) => {
+      t.equal(text, "Hello fetch-browser");
+    });
+}));
+
+test("browser fetchEngine can be used with FetchGroups", wrap((t) => {
+  t.plan(7);
+  const request = new Request(
+    `/echo/text/${encodeURIComponent("Hello fetch-browser")}`,
+  );
+  const group = new FetchGroup({
+    filters: [
+      {
+        testRequest(req) {
+          // Note: this is run multiple times for each relevant phase of the request
+          t.deepEqual(req, request);
+          return true;
+        },
+      },
+    ],
+    plugins: [
+      {
+        shouldFetch(req) {
+          t.deepEqual(req, request);
+          return true;
+        },
+      },
+    ],
+  });
+  const fetch = fetchEngine({
+    plugins: [ group ],
+  });
+  return fetch(request)
+    .then((res) => {
+      t.ok(res);
+      return res.text();
+    })
+    .then((text) => {
+      t.equal(text, "Hello fetch-browser");
+    });
+}));
+
+test("browser fetchEngine can be used with stateful FetchGroups", wrap((t) => {
+  t.plan(7);
+  const request = new Request(
+    `/echo/text/${encodeURIComponent("Hello fetch-browser")}`,
+  );
+  const Group = makeFetchGroup(() => ({
+    filters: [
+      {
+        testRequest(req) {
+          // Note: this is run multiple times for each relevant phase of the request
+          t.deepEqual(req, request);
+          return true;
+        },
+      },
+    ],
+    plugins: [
+      {
+        shouldFetch(req) {
+          t.deepEqual(req, request);
+          return true;
+        },
+      },
+    ],
+  }));
+  const fetch = fetchEngine({
+    plugins: [ new Group() ],
+  });
+  return fetch(request)
     .then((res) => {
       t.ok(res);
       return res.text();

--- a/src/fetch-engine-browser.ts
+++ b/src/fetch-engine-browser.ts
@@ -1,6 +1,7 @@
 import fetch from "./fetch/fetch-browser";
 import makeFetchEngine from "./fetchEngine";
 import FetchGroup from "./FetchGroup";
+import makeFetchGroup from "./makeFetchGroup";
 
 export default makeFetchEngine(fetch);
-export { FetchGroup };
+export { FetchGroup, makeFetchGroup };

--- a/src/makeFetchGroup.test.ts
+++ b/src/makeFetchGroup.test.ts
@@ -1,0 +1,45 @@
+// tslint:disable:no-var-requires max-classes-per-file
+require("isomorphic-fetch");
+import * as test from "tape";
+import makeFetchGroup from "./makeFetchGroup";
+
+test("groups can be created lazily", (t) => {
+  t.plan(3);
+  class MockPlugin {
+    public called: boolean = false;
+    public shouldFetch(req) {
+      this.called = true;
+      return true;
+    }
+  }
+  const GroupA = makeFetchGroup(() => ({
+    plugins: [
+      new MockPlugin(),
+    ],
+  }));
+  const a = new GroupA();
+  const b = new GroupA();
+  t.equal(a.shouldFetch(new Request("/")), true);
+  t.equal(a.plugins[0].called, true);
+  t.equal(b.plugins[0].called, false);
+});
+
+test("lazy groups support configuration", (t) => {
+  t.plan(2);
+  class MockPlugin {
+    public enabled: boolean = false;
+    public shouldFetch: () => true;
+    constructor(enabled: boolean) {
+      this.enabled = enabled;
+    }
+  }
+  const Group = makeFetchGroup((opts: { enabled: boolean }) => ({
+    plugins: [
+      new MockPlugin(opts.enabled),
+    ],
+  }));
+  const a = new Group({ enabled: true });
+  const b = new Group({ enabled: false });
+  t.equal(a.plugins[0].enabled, true);
+  t.equal(b.plugins[0].enabled, false);
+});

--- a/src/makeFetchGroup.ts
+++ b/src/makeFetchGroup.ts
@@ -1,0 +1,59 @@
+import {
+  IFetchGroupOptions,
+} from "./d";
+import FetchGroup from "./FetchGroup";
+
+/*
+ * makeFetchGroup is a utility for making reusable, possibly
+ * stateful, FetchGroups.
+ *
+ * `makeFetchGroup` takes a function that, when called, should
+ * return an object of `FetchGroup` options.
+ *
+ * It returns a constructor function.
+ *
+ * The first argument passed to the group constructor is forwared
+ * to the inner function, allowing you to customise the configuration
+ * of the group on an instance-by-instance basis.
+ *
+ * Example:
+
+    const RateLimitGroup = makeFetchGroup(() => ({
+      filters: [
+        new MethodFilter("GET")
+      ],
+      plugins: [
+        new RateLimitPlugin()
+      ]
+    }));
+
+    const fetch = fetchEngine({
+      plugins: [
+        new RateLimitGroup()
+      ]
+    });
+
+    const PathRateLimitGroup = makeFetchGroup((opts = {}) => ({
+      filters: [
+        new MethodFilter("GET"),
+        new PathFilter(opts.path)
+      ],
+      plugins: [
+        new RateLimitPlugin()
+      ]
+    }));
+
+    const fetch = fetchEngine({
+      plugins: [
+        new PathRateLimitGroup({
+          path: /^\/1\.1/
+        })
+      ]
+    });
+
+ */
+export default function makeFetchGroup<T>(
+  f: (T?) => IFetchGroupOptions,
+): (T?) => void {
+  return (t?) => new FetchGroup(f(t));
+}


### PR DESCRIPTION
`makeFetchGroup` enables reusable and stateful FetchGroups.

Closes #83.